### PR TITLE
feat: make --all default, add scheduler to dev command

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ One command installs a complete Laravel stack with AI-powered code review, consi
 
 ```bash
 composer require stumason/claudavel
-php artisan claudavel:install --all
+php artisan claudavel:install
 ```
 
 ## Why This Exists
@@ -30,7 +30,7 @@ Claude Code is powerful, but it works better when your project has clear convent
 laravel new my-app
 cd my-app
 composer require stumason/claudavel
-php artisan claudavel:install --all
+php artisan claudavel:install
 createdb my_app
 composer run dev
 ```
@@ -45,9 +45,9 @@ Add `CLAUDE_CODE_OAUTH_TOKEN` to your GitHub repo secrets to enable AI features.
 | ------------------- | ----------------------------------------------- |
 | laravel/fortify     | Authentication without Breeze/Jetstream bloat   |
 | laravel/sanctum     | API tokens                                      |
-| laravel/horizon     | Redis queue dashboard (optional)                |
-| laravel/reverb      | WebSockets without third-party services (optional) |
-| laravel/telescope   | Debug assistant (optional)                      |
+| laravel/horizon     | Redis queue dashboard                           |
+| laravel/reverb      | WebSockets without third-party services         |
+| laravel/telescope   | Debug assistant                                 |
 | laravel/pail        | Real-time log tailing                           |
 | laravel/wayfinder   | Type-safe routes in TypeScript                  |
 | sqids/sqids         | ID obfuscation                                  |
@@ -130,14 +130,24 @@ The `/health` endpoint verifies database, Redis, cache, queue, and storage. Use 
 ## Installation Options
 
 ```bash
-php artisan claudavel:install                      # Interactive prompts
-php artisan claudavel:install --all                # Install everything
-php artisan claudavel:install --horizon --reverb   # Pick specific packages
+php artisan claudavel:install                      # Install everything (default)
+php artisan claudavel:install --horizon            # Only Horizon (skip Reverb, Telescope)
 php artisan claudavel:install --no-workflows       # Skip GitHub workflows
 php artisan claudavel:install --force              # Overwrite existing files
 ```
 
 The command is idempotent - run it on existing projects and it only installs what's missing.
+
+## Development Server
+
+`composer run dev` runs everything concurrently:
+
+- Laravel dev server
+- Horizon (queue worker)
+- Reverb (WebSockets)
+- Scheduler (`schedule:work`)
+- Pail (log tailing)
+- Vite (frontend)
 
 ## Requirements
 

--- a/tests/Feature/InstallCommandTest.php
+++ b/tests/Feature/InstallCommandTest.php
@@ -157,7 +157,7 @@ test('command has all expected options', function () {
     expect($definition->hasOption('horizon'))->toBeTrue();
     expect($definition->hasOption('reverb'))->toBeTrue();
     expect($definition->hasOption('telescope'))->toBeTrue();
-    expect($definition->hasOption('all'))->toBeTrue();
+    expect($definition->hasOption('no-workflows'))->toBeTrue();
     expect($definition->hasOption('force'))->toBeTrue();
     expect($definition->hasArgument('name'))->toBeTrue();
 });


### PR DESCRIPTION
## Summary

- Remove `--all` flag - now installs everything by default (no flags needed)
- Add `php artisan schedule:work` to `composer run dev` for local scheduler
- Update README with simplified install options and new "Development Server" section
- Remove interactive prompts - the install is fully automated now

## Changes

- **InstallCommand.php**: Simplified `determinePackagesToInstall()` - defaults to all packages, flags now select specific ones only
- **README.md**: Updated examples, added dev server documentation
- **Tests**: Updated to check for `no-workflows` option instead of removed `--all`

## Test plan

- [ ] Run `php artisan claudavel:install` on fresh Laravel app - should install everything
- [ ] Run `php artisan claudavel:install --horizon` - should only install Horizon
- [ ] Verify `composer run dev` includes scheduler in output
- [ ] Run tests with `./vendor/bin/pest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)