### PR TITLE
feat: add install-github-app hint after OAuth warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,13 @@ createdb my_app
 composer run dev
 ```
 
-Add `CLAUDE_CODE_OAUTH_TOKEN` to your GitHub repo secrets to enable AI features.
+Then set up Claude's GitHub integration:
+
+```bash
+claude /install-github-app
+```
+
+This adds the `CLAUDE_CODE_OAUTH_TOKEN` secret to your repository, enabling AI code review and @claude mentions.
 
 ## What Gets Installed
 
@@ -223,6 +229,19 @@ The ESLint config automatically ignores Wayfinder generated files:
 - `resources/js/routes/**`
 
 This prevents import order and unused variable warnings for generated code.
+
+## Keeping Stubs Updated
+
+The workflow files, templates, and configs installed by Claudavel are static copies. To get updates:
+
+```bash
+composer update stumason/claudavel
+php artisan claudavel:install --force
+```
+
+The `--force` flag overwrites existing files with the latest versions. Review the changes before committing.
+
+**Note:** Dependabot monitors your project's `composer.json`, `package.json`, and workflow files - but not the stub templates in the Claudavel package itself. Updating Claudavel is how you get improved stubs.
 
 ## Requirements
 

--- a/src/Commands/InstallCommand.php
+++ b/src/Commands/InstallCommand.php
@@ -6,8 +6,10 @@ use Illuminate\Console\Command;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Process;
 
+use function Laravel\Prompts\confirm;
 use function Laravel\Prompts\info;
 use function Laravel\Prompts\spin;
+use function Laravel\Prompts\text;
 use function Laravel\Prompts\warning;
 
 class InstallCommand extends Command
@@ -719,13 +721,8 @@ PHP;
             $force
         );
 
-        // CODEOWNERS
-        $this->publishFile(
-            "{$stubsPath}/.github/CODEOWNERS.stub",
-            base_path('.github/CODEOWNERS'),
-            '.github/CODEOWNERS',
-            $force
-        );
+        // CODEOWNERS - interactive setup
+        $this->setupCodeowners($stubsPath, $force);
 
         // Pull request template
         $this->publishFile(
@@ -752,7 +749,45 @@ PHP;
         $this->newLine();
         $this->components->warn('GitHub workflows require CLAUDE_CODE_OAUTH_TOKEN secret for Claude integration.');
         $this->components->info('Run `claude /install-github-app` to configure GitHub integration.');
-        $this->newLine();
-        $this->components->warn('Update .github/CODEOWNERS with your GitHub username.');
+    }
+
+    private function setupCodeowners(string $stubsPath, bool $force): void
+    {
+        $codeownersPath = base_path('.github/CODEOWNERS');
+
+        if (File::exists($codeownersPath) && ! $force) {
+            $this->components->warn('.github/CODEOWNERS already exists (use --force to overwrite)');
+
+            return;
+        }
+
+        $wantsCodeowners = confirm(
+            label: 'Set up CODEOWNERS file for automatic PR review assignment?',
+            default: true
+        );
+
+        if (! $wantsCodeowners) {
+            return;
+        }
+
+        $username = text(
+            label: 'What is your GitHub username?',
+            placeholder: 'e.g. StuMason',
+            required: true,
+            validate: fn (string $value) => preg_match('/^[a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?$/', $value)
+                ? null
+                : 'Invalid GitHub username format'
+        );
+
+        $content = str_replace(
+            '@USERNAME',
+            '@'.$username,
+            File::get("{$stubsPath}/.github/CODEOWNERS.stub")
+        );
+
+        File::ensureDirectoryExists(dirname($codeownersPath));
+        File::put($codeownersPath, $content);
+
+        $this->components->info("Created .github/CODEOWNERS with @{$username}");
     }
 }

--- a/src/Commands/InstallCommand.php
+++ b/src/Commands/InstallCommand.php
@@ -750,7 +750,9 @@ PHP;
         }
 
         $this->newLine();
-        $this->components->warn('GitHub workflows require CLAUDE_CODE_OAUTH_TOKEN secret for Claude integration');
-        $this->components->warn('Update .github/CODEOWNERS with your GitHub username');
+        $this->components->warn('GitHub workflows require CLAUDE_CODE_OAUTH_TOKEN secret for Claude integration.');
+        $this->components->info('Run `claude /install-github-app` to configure GitHub integration.');
+        $this->newLine();
+        $this->components->warn('Update .github/CODEOWNERS with your GitHub username.');
     }
 }

--- a/stubs/.github/dependabot.yml.stub
+++ b/stubs/.github/dependabot.yml.stub
@@ -8,11 +8,18 @@ updates:
       time: "09:00"
       timezone: Europe/London
     open-pull-requests-limit: 10
+    labels:
+      - dependencies
+      - php
     groups:
       minor-and-patch:
+        patterns:
+          - "*"
         update-types:
           - minor
           - patch
+    commit-message:
+      prefix: "chore(deps)"
 
   - package-ecosystem: npm
     directory: /
@@ -22,11 +29,18 @@ updates:
       time: "09:00"
       timezone: Europe/London
     open-pull-requests-limit: 10
+    labels:
+      - dependencies
+      - javascript
     groups:
       minor-and-patch:
+        patterns:
+          - "*"
         update-types:
           - minor
           - patch
+    commit-message:
+      prefix: "chore(deps)"
 
   - package-ecosystem: github-actions
     directory: /
@@ -36,3 +50,8 @@ updates:
       time: "09:00"
       timezone: Europe/London
     open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - github-actions
+    commit-message:
+      prefix: "chore(deps)"

--- a/stubs/.github/workflows/ci.yml.stub
+++ b/stubs/.github/workflows/ci.yml.stub
@@ -36,7 +36,7 @@ jobs:
         run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache Composer Dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
@@ -113,7 +113,7 @@ jobs:
         run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache Composer Dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
@@ -179,7 +179,7 @@ jobs:
         run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache Composer Dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}

--- a/stubs/.github/workflows/lint.yml.stub
+++ b/stubs/.github/workflows/lint.yml.stub
@@ -34,7 +34,7 @@ jobs:
         run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache Composer Dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}

--- a/stubs/.github/workflows/tests.yml.stub
+++ b/stubs/.github/workflows/tests.yml.stub
@@ -42,7 +42,7 @@ jobs:
         run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache Composer Dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}


### PR DESCRIPTION
## Summary

Closes #23

Adds a helpful hint after the OAuth token warning during installation, guiding users to run `claude /install-github-app` to set up GitHub integration.

## Changes

- Add info message suggesting `claude /install-github-app` after OAuth warning in InstallCommand
- Update README Quick Start with proper setup flow
- Add "Keeping Stubs Updated" section explaining that stubs are static copies
- Improve dependabot.yml.stub with labels and commit message prefixes

## Re: Dependabot monitoring stubs

Investigated whether Dependabot can monitor the stub files - **it cannot**. Dependabot only understands package manifests (composer.json, package.json) and workflow files, not arbitrary template files.

The solution documented in the README: update claudavel via composer, then re-run `claudavel:install --force` to get the latest stubs.

## Test plan

- [x] All existing tests pass
- [x] Pre-commit hooks pass