### PR TITLE
fix(ci): unpin retired Claude models, let reviews actually post

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -10,8 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      pull-requests: write
+      issues: write
       id-token: write
 
     steps:
@@ -41,4 +41,4 @@ jobs:
 
             Use `gh pr comment` with your Bash tool to leave your review as a comment on the PR.
 
-          claude_args: '--model claude-sonnet-4-20250514 --allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
+          claude_args: '--allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -43,6 +43,5 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_args: |
-            --model claude-opus-4-5
             --allowedTools "Bash(gh:*),Bash(npm:*),Bash(composer:*)"
             --system-prompt "You can create PRs with 'gh pr create', merge with 'gh pr merge', and comment with 'gh issue comment'. Use gh CLI for all GitHub operations."

--- a/stubs/.github/workflows/claude-code-review.yml.stub
+++ b/stubs/.github/workflows/claude-code-review.yml.stub
@@ -10,8 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      pull-requests: write
+      issues: write
       id-token: write
 
     steps:

--- a/stubs/.github/workflows/claude.yml.stub
+++ b/stubs/.github/workflows/claude.yml.stub
@@ -45,6 +45,5 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_args: |
-            --model claude-opus-4-5
             --allowedTools "Bash(gh:*),Bash(npm:*),Bash(composer:*)"
             --system-prompt "You can create PRs with 'gh pr create', merge with 'gh pr merge', and comment with 'gh issue comment'. Use gh CLI for all GitHub operations."


### PR DESCRIPTION
Two silent failures in the Claude workflows, fixed in both the repo's own workflows and the published stubs:

1. **Retired model pin.** `claude-code-review.yml` pinned `claude-sonnet-4-20250514`, which was retired **2026-06-15** — review runs have been pointing at a dead model since. `claude.yml` + stub pinned legacy `claude-opus-4-5`. Pins dropped entirely so the action tracks its current default and this can't rot again.

2. **Reviews could never post.** The review workflow grants `pull-requests: read` / `issues: read`, but the prompt instructs Claude to comment via `gh pr comment` — a read-only token can't do that, so runs went green with no comment ever posted (same failure mode previously found on crunch). Bumped to `write` in the repo workflow and the stub.

Left `types: [opened]` alone — CHANGELOG says opened-only was a deliberate API-cost decision.

Full pest suite green (63 passed).