### PR TITLE
feat: ship .claude assets — /commit CDR command + permissions allowlist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,4 @@
 *.swo
 .idea/
 .vscode/
-.claude/
+/.claude/

--- a/README.md
+++ b/README.md
@@ -58,6 +58,20 @@ This adds the `CLAUDE_CODE_OAUTH_TOKEN` secret to your repository, enabling AI c
 | laravel/wayfinder   | Type-safe routes in TypeScript                  |
 | sqids/sqids         | ID obfuscation                                  |
 
+### Claude Code Assets
+
+| File                          | What it does                                                    |
+| ----------------------------- | --------------------------------------------------------------- |
+| `.claude/commands/commit.md`  | `/commit` — commits with a Conversation Decision Record         |
+| `.claude/settings.json`       | Permission allowlist (pint, pest, artisan test, git reads)      |
+| `docs/context/`               | Where CDRs live — the searchable "why" behind every commit      |
+
+**The CDR pattern:** every non-trivial `/commit` writes a short markdown record
+of the reasoning, trade-offs, and rejected alternatives from the conversation
+that produced the change, then backfills the commit SHA into it. Six months
+later, `git log` tells you what changed and `docs/context/` tells you why.
+Trivial commits (typos, dep bumps, formatting) skip the record.
+
 ### GitHub Workflows
 
 | Workflow                   | What it does                              |

--- a/src/Commands/InstallCommand.php
+++ b/src/Commands/InstallCommand.php
@@ -304,6 +304,28 @@ class InstallCommand extends Command
             $force
         );
 
+        // Claude Code assets
+        $this->publishFile(
+            "{$stubsPath}/.claude/commands/commit.md.stub",
+            base_path('.claude/commands/commit.md'),
+            '.claude/commands/commit.md',
+            $force
+        );
+
+        $this->publishFile(
+            "{$stubsPath}/.claude/settings.json.stub",
+            base_path('.claude/settings.json'),
+            '.claude/settings.json',
+            $force
+        );
+
+        $this->publishFile(
+            "{$stubsPath}/docs/context/.gitkeep.stub",
+            base_path('docs/context/.gitkeep'),
+            'docs/context/',
+            $force
+        );
+
         // Config files
         $this->publishFile(
             "{$stubsPath}/prettierrc.stub",

--- a/stubs/.claude/commands/commit.md.stub
+++ b/stubs/.claude/commands/commit.md.stub
@@ -1,0 +1,59 @@
+# /commit — commit with a Conversation Decision Record
+
+Create an atomic commit that captures not just what changed, but why. The diff
+shows the "what"; the CDR preserves the reasoning from this conversation so
+that six months from now the "why" is still in the repo.
+
+## Steps
+
+1. **Gather context.** Run `git status`, `git diff` (staged and unstaged), and
+   `git log --oneline -10` to understand what changed and match the repo's
+   commit message style.
+
+2. **Decide whether this commit needs a CDR.** Most do. Skip the CDR (go
+   straight to step 4) only for trivial changes with no reasoning worth
+   preserving: typo fixes, dependency bumps, formatting-only changes,
+   generated files. If the conversation involved a decision, trade-off, or
+   rejected alternative, write the CDR.
+
+3. **Write the CDR** at `docs/context/YYYY-MM-DD-short-slug.md`, reflecting on
+   the conversation that led to these changes — not just the diff:
+
+   ```markdown
+   # Short Title Derived From Changes
+
+   **Date:** YYYY-MM-DD
+   **Commit:** (backfilled in step 6)
+
+   ## What changed
+   Brief description of the code changes.
+
+   ## Why
+   The reasoning from the conversation. What problem were we solving?
+
+   ## Decisions made
+   - **Decision**: Chose X because Y
+
+   ## Rejected alternatives
+   Things considered but not done, and why.
+
+   ## Context
+   Relevant notes — links discussed, constraints mentioned, things to
+   revisit later.
+   ```
+
+4. **Stage specific files** — the code changes and the CDR. Never `git add -A`
+   or `git add .`; name the files.
+
+5. **Commit** with a message matching the repo's existing style. Never add
+   AI-attribution footers (no `Co-Authored-By`, no robot emoji, no
+   "Generated with" lines).
+
+6. **Backfill the SHA.** Read the new commit's short SHA, write it into the
+   CDR's `**Commit:**` line, then
+   `git add docs/context/<file> && git commit --amend --no-edit --no-verify`.
+   The `--no-verify` is deliberate: hooks already ran on the real commit;
+   re-running them on the amend doubles formatter/test time for no benefit.
+
+7. **Confirm** with a one-line summary: the SHA, the message, and the CDR path
+   (or "no CDR — trivial change").

--- a/stubs/.claude/settings.json.stub
+++ b/stubs/.claude/settings.json.stub
@@ -1,0 +1,23 @@
+{
+    "permissions": {
+        "allow": [
+            "Bash(vendor/bin/pint)",
+            "Bash(vendor/bin/pint *)",
+            "Bash(vendor/bin/pest)",
+            "Bash(vendor/bin/pest *)",
+            "Bash(php artisan test)",
+            "Bash(php artisan test *)",
+            "Bash(php artisan route:list*)",
+            "Bash(php artisan migrate:status)",
+            "Bash(php artisan config:clear)",
+            "Bash(composer test)",
+            "Bash(composer lint)",
+            "Bash(npm run build)",
+            "Bash(npm run lint)",
+            "Bash(npm run format)",
+            "Bash(git status*)",
+            "Bash(git diff*)",
+            "Bash(git log*)"
+        ]
+    }
+}

--- a/stubs/CLAUDE.md.stub
+++ b/stubs/CLAUDE.md.stub
@@ -47,6 +47,15 @@ git push -u origin feature/user-profiles
 # Create PR when feature is complete
 ```
 
+### Committing — use /commit
+
+Commit via the `/commit` command (defined in `.claude/commands/commit.md`), not
+ad-hoc `git commit`. It writes a Conversation Decision Record to
+`docs/context/` alongside each non-trivial commit — the reasoning, trade-offs,
+and rejected alternatives from the conversation — then backfills the commit SHA
+into the record. The diff shows what changed; the CDR preserves why. Trivial
+changes (typos, dep bumps, formatting) skip the CDR automatically.
+
 ---
 
 ## GitHub Interactions

--- a/stubs/docs/standards/general.md
+++ b/stubs/docs/standards/general.md
@@ -112,3 +112,13 @@ public function handle(User $user, array $data): bool
 // Bad
 public function handle($user, $data)
 ```
+
+---
+
+## Conversation Decision Records
+
+Commit through `/commit`. Non-trivial commits get a CDR in `docs/context/` —
+a short markdown file recording the reasoning, decisions, and rejected
+alternatives from the conversation that produced the change, linked to the
+commit SHA. The diff shows what changed; the CDR is the only place the *why*
+survives. Search `docs/context/` before re-litigating an old decision.

--- a/tests/Feature/InstallCommandTest.php
+++ b/tests/Feature/InstallCommandTest.php
@@ -58,11 +58,43 @@ test('all required stubs exist', function () {
         'config/claudavel.php.stub',
         'app/Actions/.gitkeep.stub',
         'app/DataTransferObjects/.gitkeep.stub',
+        '.claude/commands/commit.md.stub',
+        '.claude/settings.json.stub',
+        'docs/context/.gitkeep.stub',
     ];
 
     foreach ($requiredStubs as $stub) {
         expect(File::exists("{$stubsPath}/{$stub}"))->toBeTrue("Missing stub: {$stub}");
     }
+});
+
+test('commit command stub defines the CDR workflow', function () {
+    $content = File::get(dirname(__DIR__, 2).'/stubs/.claude/commands/commit.md.stub');
+
+    expect($content)->toContain('docs/context/')
+        ->and($content)->toContain('Rejected alternatives')
+        ->and($content)->toContain('--amend --no-edit --no-verify')
+        // never git add -A, and never AI-attribution footers
+        ->and($content)->toContain('Never `git add -A`')
+        ->and($content)->toContain('Co-Authored-By');
+});
+
+test('claude settings stub is valid json with a permissions allowlist', function () {
+    $content = File::get(dirname(__DIR__, 2).'/stubs/.claude/settings.json.stub');
+    $decoded = json_decode($content, true);
+
+    expect($decoded)->not->toBeNull()
+        ->and($decoded['permissions']['allow'])->toBeArray()
+        ->and($decoded['permissions']['allow'])->toContain('Bash(vendor/bin/pint)')
+        ->and($decoded['permissions'])->not->toHaveKey('deny');
+});
+
+test('install command publishes claude assets', function () {
+    $source = File::get(dirname(__DIR__, 2).'/src/Commands/InstallCommand.php');
+
+    expect($source)->toContain('.claude/commands/commit.md')
+        ->and($source)->toContain('.claude/settings.json')
+        ->and($source)->toContain('docs/context/.gitkeep');
 });
 
 test('health check controller stub is valid php', function () {


### PR DESCRIPTION
Closes #43, first slice of #59.

The package named 'Laravel + Claude Code configured to work together' now actually ships Claude Code assets. `claudavel:install` publishes:

| Asset | Purpose |
|---|---|
| `.claude/commands/commit.md` | The **/commit** command from #43 — writes a CDR to `docs/context/` per non-trivial commit, then backfills the SHA |
| `.claude/settings.json` | Conservative permission allowlist (pint, pest, `artisan test`, git reads) |
| `docs/context/.gitkeep` | Home for the decision records |

Design decisions (deviations from the issue as written, flagged rather than silent):
- **CDRs skip trivial commits** — typo/dep-bump/formatting diffs commit without a record; the issue's helptobuy history implies every commit gets one, but on high-frequency repos that's noise. Easy to flip by editing the command.
- **`--no-verify` on the SHA-backfill amend** — hooks already ran on the real commit; re-running them on the amend doubles formatter/test time for nothing.
- **No AI-attribution footers, ever** — baked into the command prompt.
- **Published as a `.claude/commands/` command** (as specced in #43) rather than a skill — `/commit` invokes either; can migrate to skills later without breaking anyone.
- **Gotcha fixed en route:** the repo's `.gitignore` had `.claude/` unanchored, which silently ignored the new stubs — now root-anchored (`/.claude/`).

Tests: 3 new (stub content, settings JSON validity, installer wiring) + required-stubs list extended. **66 passed (258 assertions)**, pint clean.